### PR TITLE
add user data to proxied request

### DIFF
--- a/pkg/auth/oauth.go
+++ b/pkg/auth/oauth.go
@@ -116,7 +116,7 @@ func (m *OAuthMiddleware) Wrap(next http.Handler) http.Handler {
 			userData, _ := json.Marshal(user)
 			pr.Header.Set("X-Forwarded-User-Data", string(userData))
 
-			next.ServeHTTP(w, r)
+			next.ServeHTTP(w, pr)
 			return true
 		}
 


### PR DESCRIPTION
Any application behind jhub-app-proxy is protected by the Jupyter Hub authentication. Any incoming request is checked for a cookie, which in turn is validated by trying to request the current user data from the Jupyter Hub API. However, the user information is discarded. If the proxied application needs the user information, it needs to request it again, which is unnecessarily wasteful.

This PR refactors the `validateToken` function into `getUser` and attaches the user information as JSON string to each proxied request in the `X-Forwarded-User-Data` header. Any downstream application can just read this header without any additional requests to the Jupyter Hub API.